### PR TITLE
Fix a bug where gsave_write created corrupted save files

### DIFF
--- a/src/savefile.c
+++ b/src/savefile.c
@@ -374,7 +374,7 @@ enum savefile_error gsave_parse(uint8_t *buf, size_t len, struct gsave *gs)
 static size_t skip_int32(struct buffer *out)
 {
 	size_t loc = out->index;
-	buffer_skip(out, 4);
+	buffer_write_int32(out, 0);
 	return loc;
 }
 


### PR DESCRIPTION
`buffer_skip()` does not reallocate when the remaining buffer is less than 4 bytes.

There seems to be the same bug in [`ex/pack.c`](https://github.com/nunuhara/alice-tools/blob/e5c7f65cf381319fd989e242c0412df0b9d1aa6e/src/core/ex/pack.c#L35) of alice-tools.