### PR TITLE
Avoid calling realloc() every time in gsave_add_*

### DIFF
--- a/include/system4/savefile.h
+++ b/include/system4/savefile.h
@@ -55,14 +55,18 @@ struct gsave {
 	char *group;  // version 5+
 
 	int32_t nr_records;
+	int32_t cap_records;
 	struct gsave_record *records;
 	int32_t nr_globals;
 	struct gsave_global *globals;
 	int32_t nr_strings;
+	int32_t cap_strings;
 	struct string **strings;
 	int32_t nr_arrays;
+	int32_t cap_arrays;
 	struct gsave_array *arrays;
 	int32_t nr_keyvals;
+	int32_t cap_keyvals;
 	struct gsave_keyval *keyvals;
 };
 

--- a/src/savefile.c
+++ b/src/savefile.c
@@ -484,7 +484,10 @@ int32_t gsave_add_globals_record(struct gsave *gs, int nr_globals)
 int32_t gsave_add_record(struct gsave *gs, struct gsave_record *rec)
 {
 	int32_t n = gs->nr_records++;
-	gs->records = xrealloc_array(gs->records, n, n+1, sizeof(struct gsave_record));
+	if (gs->nr_records > gs->cap_records) {
+		gs->cap_records = max(gs->nr_records, gs->cap_records * 2);
+		gs->records = xrealloc_array(gs->records, n, gs->cap_records, sizeof(struct gsave_record));
+	}
 	gs->records[n] = *rec;
 	return n;
 }
@@ -492,7 +495,10 @@ int32_t gsave_add_record(struct gsave *gs, struct gsave_record *rec)
 int32_t gsave_add_string(struct gsave *gs, struct string *s)
 {
 	int n = gs->nr_strings++;
-	gs->strings = xrealloc_array(gs->strings, n, n+1, sizeof(struct string*));
+	if (gs->nr_strings > gs->cap_strings) {
+		gs->cap_strings = max(gs->nr_strings, gs->cap_strings * 2);
+		gs->strings = xrealloc_array(gs->strings, n, gs->cap_strings, sizeof(struct string*));
+	}
 	gs->strings[n] = string_ref(s);
 	return n;
 }
@@ -500,7 +506,10 @@ int32_t gsave_add_string(struct gsave *gs, struct string *s)
 int32_t gsave_add_array(struct gsave *gs, struct gsave_array *array)
 {
 	int n = gs->nr_arrays++;
-	gs->arrays = xrealloc_array(gs->arrays, n, n+1, sizeof(struct gsave_array));
+	if (gs->nr_arrays > gs->cap_arrays) {
+		gs->cap_arrays = max(gs->nr_arrays, gs->cap_arrays * 2);
+		gs->arrays = xrealloc_array(gs->arrays, n, gs->cap_arrays, sizeof(struct gsave_array));
+	}
 	gs->arrays[n] = *array;
 	return n;
 }
@@ -508,7 +517,10 @@ int32_t gsave_add_array(struct gsave *gs, struct gsave_array *array)
 int32_t gsave_add_keyval(struct gsave *gs, struct gsave_keyval *kv)
 {
 	int n = gs->nr_keyvals++;
-	gs->keyvals = xrealloc_array(gs->keyvals, n, n+1, sizeof(struct gsave_keyval));
+	if (gs->nr_keyvals > gs->cap_keyvals) {
+		gs->cap_keyvals = max(gs->nr_keyvals, gs->cap_keyvals * 2);
+		gs->keyvals = xrealloc_array(gs->keyvals, n, gs->cap_keyvals, sizeof(struct gsave_keyval));
+	}
 	gs->keyvals[n] = *kv;
 	return n;
 }


### PR DESCRIPTION
This fixes an issue that save is extremely slow in xsystem4 on recent Android versions.