### PR TITLE
Remove palette field from `struct cg`

### DIFF
--- a/include/system4/cg.h
+++ b/include/system4/cg.h
@@ -43,12 +43,6 @@ enum cg_type {
 	_ALCG_NR_FORMATS
 };
 
-struct cg_palette {
-	uint8_t red[256];
-	uint8_t green[256];
-	uint8_t blue[256];
-};
-
 struct cg_metrics {
 	int x;
 	int y;
@@ -67,7 +61,6 @@ struct cg_metrics {
 struct cg {
 	enum cg_type type; // cg format type
 	struct cg_metrics metrics;
-	struct cg_palette *pal;
 	void *pixels;
 };
 

--- a/src/cg.c
+++ b/src/cg.c
@@ -133,7 +133,6 @@ void cg_free(struct cg *cg)
 	if (!cg)
 		return;
 	free(cg->pixels);
-	free(cg->pal);
 	free(cg);
 }
 

--- a/src/pms.c
+++ b/src/pms.c
@@ -70,17 +70,6 @@ bool pms16_checkfmt(const uint8_t *data)
 	return pms_checkfmt(data) && data[6] == 16;
 }
 
-static struct cg_palette *pms_get_palette(const uint8_t *b)
-{
-	struct cg_palette *pal = xmalloc(sizeof(struct cg_palette));
-	for (int i = 0; i < 256; i++) {
-		pal->red[i]   = *b++;
-		pal->green[i] = *b++;
-		pal->blue[i]  = *b++;
-	}
-	return pal;
-}
-
 /* Convert PMS8 image data to bitmap. */
 static uint8_t *pms8_extract(struct pms_header *pms, const uint8_t *b)
 {
@@ -279,8 +268,6 @@ bool pms_get_metrics(const uint8_t *data, struct cg_metrics *dst)
 /* Load a PMS8 CG as an alpha-map. */
 static void pms8_load(const uint8_t *data, struct pms_header *pms, struct cg *cg)
 {
-	cg->pal = pms_get_palette(data + pms->pp);
-
 	cg->type = ALCG_PMS8;
 	uint8_t *alpha = pms8_extract(pms, data + pms->dp);
 


### PR DESCRIPTION
It's unused, as the CG extraction functions depalettize paletted images internally.