### PR TITLE
Normalize path separators when matching archive entry names

### DIFF
--- a/include/system4/utfsjis.h
+++ b/include/system4/utfsjis.h
@@ -37,8 +37,7 @@ extern char* utf2sjis(const char *src, size_t len);
 extern bool  sjis_has_hankaku(const char *src);
 extern bool  sjis_has_zenkaku(const char *src);
 extern int   sjis_count_char(const char *src);
-extern void  sjis_toupper(char *src);
-extern char* sjis_toupper2(const char *src, size_t len);
+extern void  sjis_normalize_path(char *src);
 
 // Returns (big-endian) SJIS codepoint for first character in a string.
 static inline uint16_t sjis_code(const char *_str)

--- a/src/aar.c
+++ b/src/aar.c
@@ -33,7 +33,7 @@
 static void *ht_get_ignorecase(struct hash_table *ht, const char *key, void *dflt)
 {
 	char *uc_key = strdup(key);
-	sjis_toupper(uc_key);
+	sjis_normalize_path(uc_key);
 	void *r = ht_get(ht, uc_key, dflt);
 	free(uc_key);
 	return r;
@@ -42,7 +42,7 @@ static void *ht_get_ignorecase(struct hash_table *ht, const char *key, void *dfl
 struct ht_slot *ht_put_ignorecase(struct hash_table *ht, const char *key, void *dflt)
 {
 	char *uc_key = strdup(key);
-	sjis_toupper(uc_key);
+	sjis_normalize_path(uc_key);
 	void *r = ht_put(ht, uc_key, dflt);
 	free(uc_key);
 	return r;

--- a/src/archive.c
+++ b/src/archive.c
@@ -68,6 +68,6 @@ char *archive_basename(const char *name)
 	char *dot = strrchr(basename, '.');
 	if (dot)
 		*dot = '\0';
-	sjis_toupper(basename);
+	sjis_normalize_path(basename);
 	return basename;
 }

--- a/src/utfsjis.c
+++ b/src/utfsjis.c
@@ -191,29 +191,15 @@ int sjis_count_char(const char *_src) {
 	return c;
 }
 
-/* SJIS(EUC) を含む文字列の ASCII を大文字化する */
-void sjis_toupper(char *_src) {
-	uint8_t *src = (uint8_t*)_src;
-	while(*src) {
+// Replaces lowercase letters with uppercase letters and slashes with backslashes.
+void sjis_normalize_path(char *_src) {
+	for (uint8_t *src = (uint8_t*)_src; *src; src++) {
 		if (SJIS_2BYTE(*src)) {
 			src++;
-		} else {
-			if (*src >= 0x60 && *src <= 0x7a) {
-				*src &= 0xdf;
-			}
+		} else if ('a' <= *src && *src <= 'z') {
+			*src -= 'a' - 'A';
+		} else if (*src == '/') {
+			*src = '\\';
 		}
-		src++;
 	}
-}
-
-/* SJIS を含む文字列の ASCII を大文字化する2 */
-char *sjis_toupper2(const char *_src, size_t len) {
-	const uint8_t *src = (uint8_t*)_src;
-	uint8_t *dst;
-
-	dst = malloc(len +1);
-	if (dst == NULL) return NULL;
-	strcpy((char*)dst, (char*)src);
-	sjis_toupper((char*)dst);
-	return (char*)dst;
 }


### PR DESCRIPTION
This makes the archive functions to equate forward slashes and backslashes when finding entries by name.

This is necessary in Daiteikoku, to access the Flash archive.

Also, fixes a bug that ``'`'`` (0x60) and `'@'` were equated.