### PR TITLE
string_set_char truncates string when character is null

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -299,6 +299,13 @@ void string_set_char(struct string **_str, int i, unsigned int c)
 	if ((i = sjis_index(str->text, i)) < 0)
 		return;
 
+	if (c == 0) {
+		// truncate
+		str->text[i] = '\0';
+		str->size = i;
+		return;
+	}
+
 	bytes_src = SJIS_2BYTE(c) ? 2 : 1;
 	bytes_dst = SJIS_2BYTE(str->text[i]) ? 2 : 1;
 


### PR DESCRIPTION
In System4, `string[n] = 0` (where n < `string.Length()`) truncates the string to n characters.

This fixes a layout issue with text containing ruby in Shimaima.

![shimaima](https://github.com/nunuhara/libsys4/assets/12679772/97640db2-4865-4377-954f-ee84c226b6c4)
