### PR TITLE
Improve ALD header un-obfuscation

### DIFF
--- a/src/ald.c
+++ b/src/ald.c
@@ -69,10 +69,17 @@ static bool get_table_sizes(FILE *fp, int *ptrsize_out, int *mapsize_out)
 		return false;
 
 	// un-obfuscate the first 3 bytes if necessary
-	if (b[1] == 'L' && b[2] == 'D') {
+	switch (b[2]) {
+	case 0x44:  // Sengoku Rance DL edition, Haruka DL edition
 		b[0] -= 0x40;
-		b[1] = 0x00;
+		b[1] -= 0x4c;
 		b[2] = 0x00;
+		break;
+	case 0x14:  // GALZOO island DL edition
+		b[0] -= 0x17;
+		b[1] -= 0x1c;
+		b[2] = 0x00;
+		break;
 	}
 
 	// get ptrsize and mapsize


### PR DESCRIPTION
This fixes https://github.com/kichikuou/xsystem4-android/issues/1.

In the download editions of some games, the first three bytes of ALD are obfuscated. Before this patch, only the download edition of Sengoku Rance was confirmed to work. This patch adds support for ALDS in the download edition of GALZOO Island and Choukou Sennin Haruka.

- Haruka uses the same magic number as Sengoku Rance, but the existing code did not work when the second byte was not 0x4c (i.e. when ALD has more entries than 21845).
- GALZOO uses a different magic number.