### PR TITLE
Support resume save with only comments

### DIFF
--- a/include/system4/savefile.h
+++ b/include/system4/savefile.h
@@ -137,6 +137,7 @@ struct rsave {
 	char *key;
 	int32_t nr_comments;  // version 7+
 	char **comments;
+	bool comments_only;  // if true, the following fields are not used
 	struct rsave_return_record ip;
 	int32_t uk1;  // always zero
 	int32_t stack_size;


### PR DESCRIPTION
`system.ResumeWriteComment()` creates a comment-only save file if given a non-existent filename. This allows such save files to be handled by `rsave_{read/write}`.