### PR TITLE
Export utf8_to_wchar and wchar_to_utf8 in Win32

### DIFF
--- a/include/system4/utfsjis.h
+++ b/include/system4/utfsjis.h
@@ -39,6 +39,11 @@ extern bool  sjis_has_zenkaku(const char *src);
 extern int   sjis_count_char(const char *src);
 extern void  sjis_normalize_path(char *src);
 
+#ifdef _WIN32
+wchar_t *utf8_to_wchar(const char *str);
+char *wchar_to_utf8(const wchar_t *wstr);
+#endif
+
 // Returns (big-endian) SJIS codepoint for first character in a string.
 static inline uint16_t sjis_code(const char *_str)
 {

--- a/src/file.c
+++ b/src/file.c
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 #include "system4.h"
 #include "system4/file.h"
+#include "system4/utfsjis.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -35,22 +36,6 @@
 #endif
 
 #ifdef _WIN32
-static wchar_t *utf8_to_wchar(const char *str)
-{
-	int nr_wchars = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
-	wchar_t *wstr = xmalloc(nr_wchars * sizeof(wchar_t));
-	MultiByteToWideChar(CP_UTF8, 0, str, -1, wstr, nr_wchars);
-	return wstr;
-}
-
-static char *wchar_to_utf8(const wchar_t *wstr)
-{
-	int nr_chars = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
-	char *str = xmalloc(nr_chars);
-	WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, nr_chars, NULL, NULL);
-	return str;
-}
-
 static int make_dir(const char *path, possibly_unused int mode)
 {
 	wchar_t *wpath = utf8_to_wchar(path);

--- a/src/utfsjis.c
+++ b/src/utfsjis.c
@@ -203,3 +203,23 @@ void sjis_normalize_path(char *_src) {
 		}
 	}
 }
+
+#ifdef _WIN32
+#include <windows.h>
+
+wchar_t *utf8_to_wchar(const char *str)
+{
+	int nr_wchars = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+	wchar_t *wstr = xmalloc(nr_wchars * sizeof(wchar_t));
+	MultiByteToWideChar(CP_UTF8, 0, str, -1, wstr, nr_wchars);
+	return wstr;
+}
+
+char *wchar_to_utf8(const wchar_t *wstr)
+{
+	int nr_chars = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
+	char *str = xmalloc(nr_chars);
+	WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, nr_chars, NULL, NULL);
+	return str;
+}
+#endif


### PR DESCRIPTION
I'm going to use this in xsystem4 to implement `bgm_prepare_from_file()`, like this:

```c
#ifdef _WIN32
	wchar_t *wpath = utf8_to_wchar(path);
	ch->file = sf_wchar_open(wpath, SFM_READ, &ch->info);
	free(wpath);
#else
	ch->file = sf_open(path, SFM_READ, &ch->info);
#endif
```
