### PR TITLE
afa: support Rance Quest Magnum Integrated Edition

### DIFF
--- a/include/system4/afa.h
+++ b/include/system4/afa.h
@@ -44,6 +44,7 @@ struct afa_archive {
 	uint32_t data_start;
 	uint32_t compressed_size;
 	uint32_t uncompressed_size;
+	bool has_number;
 	uint32_t nr_files;
 	struct afa_entry *files;
 	uint32_t data_size;


### PR DESCRIPTION
Rance Quest Magnum Integrated Edition uses afa version=2 but has the numeric ID field in the file table.

The presence or absence of the ID field cannot be determined from the file header, so it needs to be determined by scanning the file table.