### PR TITLE
ald: Magic number detection

### DIFF
--- a/include/system4/ald.h
+++ b/include/system4/ald.h
@@ -39,6 +39,8 @@ struct ald_archive {
 		char *name;
 		FILE *fp;
 	} files[ALD_FILEMAX];
+	// magic number added to the first 3 bytes of the archive
+	uint8_t magic[3];
 	// upper limit on how many files could be referenced by this archive
 	int maxfile;
 	// file numbers (from the file map)


### PR DESCRIPTION
ALD archives in downloadable edition of some games are obfuscated by adding a fixed value to the first 3 bytes of the archive. Since this magic number varies from game to game, this change scans the pointer table to determine the correct value of the first 3 bytes, and then calculates the magic number from there.

This logic has been used at https://xsystem4-pwa.web.app/ for 9 months and no problems have been reported.