### PR TITLE
readdir_utf8: Normalize file names to NFC on Apple platforms

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,8 +3,12 @@ project('libsys4', 'c',
 add_project_arguments('-D_DEFAULT_SOURCE', language : 'c')
 
 static_libs = false
+platform_deps = []
 if host_machine.system() == 'windows'
     static_libs = true
+endif
+if host_machine.system() == 'darwin'
+    platform_deps = dependency('appleframeworks', modules : 'CoreFoundation')
 endif
 
 zlib = dependency('zlib', static : static_libs)
@@ -66,7 +70,7 @@ system4 += flexgen.process('src/ini_lexer.l')
 system4 += bisongen.process('src/ini_parser.y')
 
 libsys4 = library('sys4', system4,
-                  dependencies : [libm, zlib, tj, webp, png],
+                  dependencies : [libm, zlib, tj, webp, png] + platform_deps,
                   include_directories : [inc, local_inc],
                   install : true)
 


### PR DESCRIPTION
In macOS/iOS file systems (HFS+ and APFS), file names are stored in Unicode NFD (Normalization Form Decomposed). For example, U+304C (HIRAGANA LETTER GA) is converted to two characters, U+304B (HIRAGANA LETTER KA) and U+3099 (COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK).

This is problematic for file name comparisons, so this change makes `readdir_utf8()` normalize file names to NFC on Apple platforms and WebAssembly.