### PR TITLE
fnl: Do not load entire fnl file into memory

### DIFF
--- a/include/system4/fnl.h
+++ b/include/system4/fnl.h
@@ -21,10 +21,10 @@
 #include <stdio.h>
 
 struct fnl {
-	uint8_t *data;
+	FILE *file;
 	uint32_t filesize;
 	uint32_t uk;
-	uint32_t data_offset;
+	uint32_t index_size;
 	uint32_t nr_fonts;
 	struct fnl_font *fonts;
 


### PR DESCRIPTION
Fnl file can be large (240MB in Daiteikoku), so this makes `fnl_open()` read only the index into memory, and `fnl_glyph_data()` read the glyph data from the file as needed.