### PR TITLE
QNT: Handle alpha-only images correctly

### DIFF
--- a/src/qnt.c
+++ b/src/qnt.c
@@ -251,7 +251,9 @@ void qnt_extract(const uint8_t *data, struct cg *cg)
 	qnt_init_metrics(&qnt, &cg->metrics);
 
 	uint8_t *pixels = xcalloc(3, (qnt.width+10) * (qnt.height+10));
-	extract_pixel(&qnt, pixels, data + qnt.hdr_size);
+	if (qnt.pixel_size) {
+		extract_pixel(&qnt, pixels, data + qnt.hdr_size);
+	}
 
 	cg->type = ALCG_QNT;
 


### PR DESCRIPTION
The lightmap textures for Rance 6 and GALZOO Island are QNT images that only contain an alpha channel, with no pixel data.

The existing code attempted to call `extract_pixel` on these files, which in turn would try to uncompress an empty buffer, leading to a `WARNING()`.