### PR TITLE
FLAT: parse FLAT header (v1=32B, v2=64B)

### DIFF
--- a/include/system4/flat.h
+++ b/include/system4/flat.h
@@ -53,6 +53,31 @@ struct talt_entry {
 	struct talt_metadata *metadata;
 };
 
+enum flat_header_type {
+	FLAT_HDR_UNKNOWN,
+	FLAT_HDR_V1_32, // 32-bytes
+	FLAT_HDR_V2_64,
+};
+
+struct flat_header {
+	bool present;
+
+	enum flat_header_type type;
+
+	// V2-only
+	int32_t uk1; // Comes before fps in V2 only
+
+	// Common fields
+	int32_t fps;
+	int32_t game_view_width;
+	int32_t game_view_height;
+	float camera_length;
+	float meter;
+	int32_t width;
+	int32_t height;
+	int32_t uk2; // Present in V1 and V2, but explicitly skipped in earlier games
+};
+
 struct flat_data {
 	struct archive_data super;
 	size_t off;
@@ -77,6 +102,8 @@ struct flat_archive {
 	struct flat_section mtlc;
 	struct flat_section libl;
 	struct flat_section talt;
+
+	struct flat_header fh;
 
 	uint32_t nr_libl_entries;
 	struct libl_entry *libl_entries;


### PR DESCRIPTION
## Summary
Parse the FLAT section header. Version is detected by section size.

## Layout
### V1
Offset | Size | Type | Name | Notes
-- | -- | -- | -- | --
0x00 | 4 | i32 | fps |  
0x04 | 4 | i32 | game_view_width |  
0x08 | 4 | i32 | game_view_height |  
0x0C | 4 | f32 | camera_length |  
0x10 | 4 | f32 | meter |  
0x14 | 4 | i32 | width | often 0
0x18 | 4 | i32 | height | often 0
0x1C | 4 | i32 | uk2 | skipped in earlier games kept in later
### V2

Offset | Size | Type | Name | Notes
-- | -- | -- | -- | --
0x00 | 4 | i32 | uk1 | v2-only leading int
0x04 | 4 | i32 | fps |  
0x08 | 4 | i32 | game_view_width |  
0x0C | 4 | i32 | game_view_height |  
0x10 | 4 | f32 | camera_length |  
0x14 | 4 | f32 | meter |  
0x18 | 4 | i32 | width | often 0
0x1C | 4 | i32 | height | often 0
0x20 | 4 | i32 | uk2 |  
0x24 | 28 | u32 | reserved[7] | present but seem to be skipped as of Rance 9


## Behaviour

-  section_size == 32 -> read v1
-  section_size == 64 -> read v2
-  otherwise: warn set fh.present to false and fh.type = FLAT_HDR_UNKOWN (non-fatal)

## Testing
Verified on titles I got from around Rance 9 up to Rance 10