### PR TITLE
FLAT: parse MTLC section

### DIFF
--- a/include/system4/flat.h
+++ b/include/system4/flat.h
@@ -65,7 +65,7 @@ struct flat_header {
 	enum flat_header_type type;
 
 	// V2-only
-	int32_t uk1; // Comes before fps in V2 only
+	int32_t uk1;
 
 	// Common fields
 	int32_t fps;
@@ -75,7 +75,82 @@ struct flat_header {
 	float meter;
 	int32_t width;
 	int32_t height;
-	int32_t uk2; // Present in V1 and V2, but explicitly skipped in earlier games
+	int32_t version;
+};
+
+enum flat_timeline_type {
+	FLAT_TIMELINE_GRAPHIC = 3,
+	FLAT_TIMELINE_SOUND = 4,
+	FLAT_TIMELINE_SCRIPT = 5,
+};
+
+struct flat_key_data_graphic {
+	// After version 4 position is stored as float
+	union { int32_t i; float f; } pos_x;
+	union { int32_t i; float f; } pos_y;
+	float scale_x;
+	float scale_y;
+	float angle_x;
+	float angle_y;
+	float angle_z;
+	int32_t add_r;
+	int32_t add_g;
+	int32_t add_b;
+	int32_t mul_r;
+	int32_t mul_g;
+	int32_t mul_b;
+	int32_t alpha;
+	int32_t area_x;
+	int32_t area_y;
+	int32_t area_width;
+	int32_t area_height;
+	int32_t draw_filter;
+	int32_t uk1; // only version > 8
+	int32_t origin_x;
+	int32_t origin_y;
+	int32_t uk2; // Only version > 7
+	bool reverse_tb; // Top/bottom
+	bool reverse_lr; // Left/right
+};
+
+struct flat_key_frame_graphic {
+	uint32_t count;
+	struct flat_key_data_graphic *keys;
+};
+
+struct flat_graphic_timeline {
+	// v < 15
+	uint32_t count;
+	struct flat_key_data_graphic *keys;
+
+	// v >= 15
+	struct flat_key_frame_graphic *frames;
+};
+
+struct flat_script_key {
+	uint32_t frame_index;
+	bool has_jump;
+	int32_t jump_frame;
+	bool is_stop;
+	struct string *text;
+};
+
+struct flat_script_timeline {
+	uint32_t count;
+	struct flat_script_key *keys;
+};
+
+
+struct flat_timeline {
+	struct string *name;
+	struct string *library_name;
+	enum flat_timeline_type type;
+	int32_t begin_frame;
+	int32_t frame_count;
+	union {
+		struct flat_graphic_timeline graphic;
+		struct flat_script_timeline script;
+	};
 };
 
 struct flat_data {
@@ -109,6 +184,8 @@ struct flat_archive {
 	struct libl_entry *libl_entries;
 	uint32_t nr_talt_entries;
 	struct talt_entry *talt_entries;
+	uint32_t nr_mtlc_timelines;
+	struct flat_timeline *mtlc_timelines;
 
 	bool needs_free;
 	size_t data_size;


### PR DESCRIPTION
## Summary
Adds parsing for the MTLC section and implements parsing for Script and Graphic timelines. There is a Sound timeline as well but I have not found a flat that uses it so it remains unimplemented.


## Changes
### Header cleanup
  - Replace `uk2` with `version` (V1/V2)
  - Read `version` first for V2; move `uk1` to the trailing slot

### MTLC parsing:
  - Implement reader for MTLC payloads (uncompressed and zlib-compressed when `fh.version >= 4`).
  - Add 4-byte-aligned Pascal string helper

### Graphic timelines:
  - Support v<15: one key per frame.
  - Support v>=15: **per-frame key counts** with allocations per frame. Though in most cases there is only one key.
  - Version-aware key size (92/96/100 bytes) and field gating (`uk1`, `uk2`).

### Script timelines:
  - Implement key reader with opcode: 0 = end, 1 = jump_frame, 2 = stop, 3 = string payload
  
## Testing
Parsed ~2000 `.flat` files from 2014–2018 with no errors or warnings using a fail-on-stderr sweep.
